### PR TITLE
Add Clear Linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 | Debian | 8 & 9 |[![Docker Pulls](https://img.shields.io/docker/pulls/paulfantom/debian-molecule.svg)](https://hub.docker.com/r/paulfantom/debian-molecule) |
 | Ubuntu | 16.04 & 18.04 | [![Docker Pulls](https://img.shields.io/docker/pulls/paulfantom/ubuntu-molecule.svg)](https://hub.docker.com/r/paulfantom/ubuntu-molecule) |
 | OpenSUSE | Leap 15.0 | [![Docker Pulls](https://img.shields.io/docker/pulls/paulfantom/opensuse-molecule.svg)](https://hub.docker.com/r/paulfantom/opensuse-molecule) |
+| Clear Linux | latest | [![Docker Pulls](https://img.shields.io/docker/pulls/paulfantom/clearlinux-molecule.svg)](https://hub.docker.com/r/paulfantom/clearlinux-molecule) |
 
 Repository contains docker images for [molecule](https://github.com/metacloud/molecule) testing framework. Those images aren't supposed to run anywhere outside CI pipeline.
 Every image comes with packages:

--- a/systemd/clearlinux/Dockerfile
+++ b/systemd/clearlinux/Dockerfile
@@ -1,0 +1,15 @@
+FROM clearlinux:latest
+
+ENV container docker
+
+RUN swupd bundle-add python2-basic network-basic
+
+RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
+    /lib/systemd/system/sockets.target.wants/*udev* \
+    /lib/systemd/system/sockets.target.wants/*initctl*
+
+RUN systemctl set-default multi-user.target
+ENV init /lib/systemd/systemd
+VOLUME [ "/sys/fs/cgroup" ]
+
+ENTRYPOINT ["/usr/lib/systemd/systemd"]


### PR DESCRIPTION
This pull request adds a new `Dockerfile` for the [Clear Linux](https://clearlinux.org/) distribution.

I struggled with which version to use in this commit, because Clear Linux is an [auto-updating](https://clearlinux.org/documentation/clear-linux/concepts/swupd-about#updating) distribution. As a result, I opted to use the `latest` Docker Hub tag.

The closest thing to a package manager that Clear Linux has is called `swupd`, and the general idea is that _bundles_ of packages are installed. I made sure that the bundles in this pull request install each of the packages outlined in the `README.md`.

I assume that the badges in the `README.md` won't work until the appropriate Docker Hub images are created.