### PR TITLE
Add sudo bundle for Clear Linux

### DIFF
--- a/systemd/clearlinux/Dockerfile
+++ b/systemd/clearlinux/Dockerfile
@@ -2,7 +2,7 @@ FROM clearlinux:latest
 
 ENV container docker
 
-RUN swupd bundle-add python2-basic network-basic
+RUN swupd bundle-add sudo python2-basic network-basic
 
 RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
     /lib/systemd/system/sockets.target.wants/*udev* \


### PR DESCRIPTION
This pull request builds on #2 and resolves the error seen in CI [here](https://travis-ci.org/cloudalchemy/ansible-node-exporter/jobs/429834103):

```
failed: [clearlinux] (item=None) => {"changed": false, "item": null, "module_stderr": "/bin/sh: sudo: command not found\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 127}
```