### PR TITLE
Don't require Clear Linux root password on boot

### DIFF
--- a/systemd/clearlinux/Dockerfile
+++ b/systemd/clearlinux/Dockerfile
@@ -4,6 +4,8 @@ ENV container docker
 
 RUN swupd bundle-add sudo python2-basic network-basic
 
+RUN echo "root::17792::::::" > /etc/shadow
+
 RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
     /lib/systemd/system/sockets.target.wants/*udev* \
     /lib/systemd/system/sockets.target.wants/*initctl*


### PR DESCRIPTION
This is hopefully the last piece of the puzzle for https://github.com/paulfantom/dockerfiles/pull/2. By default, Clear Linux requires you to change the root password on the first boot. This pull request sets the "last password change" of `/etc/shadow` so that's no longer required.